### PR TITLE
mpsc::peek

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -35,7 +35,7 @@ __docs_rs = ["futures-util"]
 
 [dependencies]
 tokio = { version = "1.28.0", path = "../tokio", features = ["sync"] }
-bytes = "1.0.0"
+bytes = "1.2.1"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }

--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -2,7 +2,6 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use bytes::{Buf, BufMut};
 use std::io::{self, IoSlice};
-use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
@@ -59,7 +58,7 @@ pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
 
         // Safety: `chunk_mut()` returns a `&mut UninitSlice`, and `UninitSlice` is a
         // transparent wrapper around `[MaybeUninit<u8>]`.
-        let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
+        let dst = unsafe { dst.as_uninit_slice_mut() };
         let mut buf = ReadBuf::uninit(dst);
         let ptr = buf.filled().as_ptr();
         ready!(io.poll_read(cx, &mut buf)?);

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -91,7 +91,7 @@ tokio-macros = { version = "~2.5.0", path = "../tokio-macros", optional = true }
 pin-project-lite = "0.2.11"
 
 # Everything else is optional...
-bytes = { version = "1.1.0", optional = true }
+bytes = { version = "1.2.1", optional = true }
 mio = { version = "1.0.1", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -587,6 +587,7 @@ impl AsyncRead for File {
         dst: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         ready!(crate::trace::trace_leaf(cx));
+
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
@@ -595,7 +596,7 @@ impl AsyncRead for File {
                 State::Idle(ref mut buf_cell) => {
                     let mut buf = buf_cell.take().unwrap();
 
-                    if !buf.is_empty() {
+                    if !buf.is_empty() || dst.remaining() == 0 {
                         buf.copy_to(dst);
                         *buf_cell = Some(buf);
                         return Poll::Ready(Ok(()));

--- a/tokio/src/fs/hard_link.rs
+++ b/tokio/src/fs/hard_link.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 ///
 /// This is an async version of [`std::fs::hard_link`].
 ///
-/// The `dst` path will be a link pointing to the `src` path. Note that systems
+/// The `link` path will be a link pointing to the `original` path. Note that systems
 /// often require these two paths to both be located on the same filesystem.
 ///
 /// # Platform-specific behavior
@@ -23,7 +23,7 @@ use std::path::Path;
 /// This function will return an error in the following situations, but is not
 /// limited to just these cases:
 ///
-/// * The `src` path is not a file or doesn't exist.
+/// * The `original` path is not a file or doesn't exist.
 ///
 /// # Examples
 ///
@@ -36,9 +36,9 @@ use std::path::Path;
 ///     Ok(())
 /// }
 /// ```
-pub async fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    let src = src.as_ref().to_owned();
-    let dst = dst.as_ref().to_owned();
+pub async fn hard_link(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    let original = original.as_ref().to_owned();
+    let link = link.as_ref().to_owned();
 
-    asyncify(move || std::fs::hard_link(src, dst)).await
+    asyncify(move || std::fs::hard_link(original, link)).await
 }

--- a/tokio/src/fs/symlink.rs
+++ b/tokio/src/fs/symlink.rs
@@ -5,12 +5,12 @@ use std::path::Path;
 
 /// Creates a new symbolic link on the filesystem.
 ///
-/// The `dst` path will be a symbolic link pointing to the `src` path.
+/// The `link` path will be a symbolic link pointing to the `original` path.
 ///
 /// This is an async version of [`std::os::unix::fs::symlink`].
-pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    let src = src.as_ref().to_owned();
-    let dst = dst.as_ref().to_owned();
+pub async fn symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    let original = original.as_ref().to_owned();
+    let link = link.as_ref().to_owned();
 
-    asyncify(move || std::os::unix::fs::symlink(src, dst)).await
+    asyncify(move || std::os::unix::fs::symlink(original, link)).await
 }

--- a/tokio/src/fs/symlink_dir.rs
+++ b/tokio/src/fs/symlink_dir.rs
@@ -5,15 +5,15 @@ use std::path::Path;
 
 /// Creates a new directory symlink on the filesystem.
 ///
-/// The `dst` path will be a directory symbolic link pointing to the `src`
+/// The `link` path will be a directory symbolic link pointing to the `original`
 /// path.
 ///
 /// This is an async version of [`std::os::windows::fs::symlink_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
-pub async fn symlink_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    let src = src.as_ref().to_owned();
-    let dst = dst.as_ref().to_owned();
+pub async fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    let original = original.as_ref().to_owned();
+    let link = link.as_ref().to_owned();
 
-    asyncify(move || std::os::windows::fs::symlink_dir(src, dst)).await
+    asyncify(move || std::os::windows::fs::symlink_dir(original, link)).await
 }

--- a/tokio/src/fs/symlink_file.rs
+++ b/tokio/src/fs/symlink_file.rs
@@ -5,15 +5,15 @@ use std::path::Path;
 
 /// Creates a new file symbolic link on the filesystem.
 ///
-/// The `dst` path will be a file symbolic link pointing to the `src`
+/// The `link` path will be a file symbolic link pointing to the `original`
 /// path.
 ///
 /// This is an async version of [`std::os::windows::fs::symlink_file`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
-pub async fn symlink_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    let src = src.as_ref().to_owned();
-    let dst = dst.as_ref().to_owned();
+pub async fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    let original = original.as_ref().to_owned();
+    let link = link.as_ref().to_owned();
 
-    asyncify(move || std::os::windows::fs::symlink_file(src, dst)).await
+    asyncify(move || std::os::windows::fs::symlink_file(original, link)).await
 }

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -41,7 +41,6 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         use crate::io::ReadBuf;
-        use std::mem::MaybeUninit;
 
         let me = self.project();
 
@@ -51,7 +50,7 @@ where
 
         let n = {
             let dst = me.buf.chunk_mut();
-            let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
+            let dst = unsafe { dst.as_uninit_slice_mut() };
             let mut buf = ReadBuf::uninit(dst);
             let ptr = buf.filled().as_ptr();
             ready!(Pin::new(me.reader).poll_read(cx, &mut buf)?);

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1164,8 +1164,8 @@ impl UdpSocket {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
-        let mut addrs = to_socket_addrs(target).await?;
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
+        let mut addrs = to_socket_addrs(addr).await?;
 
         match addrs.next() {
             Some(target) => self.send_to_addr(buf, target).await,

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -400,7 +400,7 @@ impl<T> Rx<T> {
                 let res = Self::advance_step(&mut next_head, index);
                 return res.map_break(|_advanced_to_next_block| ());
             }
-            return ControlFlow::Break(())
+            ControlFlow::Break(())
         };
 
         while advance_if_final(self.index.wrapping_add(index)).is_continue() {
@@ -421,12 +421,8 @@ impl<T> Rx<T> {
             }
 
             match block.load_next(Acquire) {
-                Some(next_block) => {
-                    next_block
-                }
-                None => {
-                    return ControlFlow::Break(false)
-                }
+                Some(next_block) => next_block,
+                None => return ControlFlow::Break(false)
             }
         };
 

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -5,6 +5,7 @@ use crate::loom::thread;
 use crate::sync::mpsc::block::{self, Block};
 
 use std::fmt;
+use std::ops::ControlFlow;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 
@@ -30,8 +31,8 @@ pub(crate) struct Rx<T> {
     free_head: NonNull<Block<T>>,
 }
 
-/// Return value of `Rx::try_pop`.
-pub(crate) enum TryPopResult<T> {
+/// Return value of `Rx::try_pop` and `Rx::try_peek`.
+pub(crate) enum TryReadResult<T> {
     /// Successfully popped a value.
     Ok(T),
     /// The channel is empty.
@@ -257,10 +258,19 @@ impl<T> Rx<T> {
         tail_position - self.index - (tx.is_closed() as usize)
     }
 
+    pub(crate) fn peek(&self) -> Option<block::Read<&T>> {
+        let head = self.try_peeking_ahead();
+        unsafe {
+            let block = head.as_ref();
+            let ret = block.peek(self.index);
+            ret
+        }
+    }
+
     /// Pops the next value off the queue.
     pub(crate) fn pop(&mut self, tx: &Tx<T>) -> Option<block::Read<T>> {
         // Advance `head`, if needed
-        if !self.try_advancing_head() {
+        if !Self::try_advancing_head(&mut self.head, self.index) {
             return None;
         }
 
@@ -287,44 +297,39 @@ impl<T> Rx<T> {
     /// This can happen if the fully delivered message is behind another message
     /// that is in the middle of being written to the block, since the channel
     /// can't return the messages out of order.
-    pub(crate) fn try_pop(&mut self, tx: &Tx<T>) -> TryPopResult<T> {
+    pub(crate) fn try_pop(&mut self, tx: &Tx<T>) -> TryReadResult<T> {
         let tail_position = tx.tail_position.load(Acquire);
         let result = self.pop(tx);
 
         match result {
-            Some(block::Read::Value(t)) => TryPopResult::Ok(t),
-            Some(block::Read::Closed) => TryPopResult::Closed,
-            None if tail_position == self.index => TryPopResult::Empty,
-            None => TryPopResult::Busy,
+            Some(block::Read::Value(t)) => TryReadResult::Ok(t),
+            Some(block::Read::Closed) => TryReadResult::Closed,
+            None if tail_position == self.index => TryReadResult::Empty,
+            None => TryReadResult::Busy,
+        }
+    }
+
+    // TODO: Unify logic with try_pop
+    pub(crate) fn try_peek(&self, tx: &Tx<T>) -> TryReadResult<&T> {
+        let tail_position = tx.tail_position.load(Acquire);
+        let result = self.peek();
+
+        match result {
+            Some(block::Read::Value(t)) => TryReadResult::Ok(t),
+            Some(block::Read::Closed) => TryReadResult::Closed,
+            None if tail_position == self.index => TryReadResult::Empty,
+            None => TryReadResult::Busy,
         }
     }
 
     /// Tries advancing the block pointer to the block referenced by `self.index`.
     ///
     /// Returns `true` if successful, `false` if there is no next block to load.
-    fn try_advancing_head(&mut self) -> bool {
-        let block_index = block::start_index(self.index);
-
+    fn try_advancing_head<I>(head: &mut NonNull<Block<I>>, index: usize) -> bool {
         loop {
-            let next_block = {
-                let block = unsafe { self.head.as_ref() };
-
-                if block.is_at_index(block_index) {
-                    return true;
-                }
-
-                block.load_next(Acquire)
-            };
-
-            let next_block = match next_block {
-                Some(next_block) => next_block,
-                None => {
-                    return false;
-                }
-            };
-
-            self.head = next_block;
-
+            if let ControlFlow::Break(was_successful) = Self::advance_step(head, index) {
+                return was_successful;
+            }
             thread::yield_now();
         }
     }
@@ -385,6 +390,59 @@ impl<T> Rx<T> {
             drop(Box::from_raw(block.as_ptr()));
         }
     }
+
+    fn try_peeking_ahead(&self) -> NonNull<Block<T>> {
+        let mut next_head: NonNull<Block<T>> = self.head;
+        let mut index  = 0;
+
+        let mut advance_if_final = |index: usize| {
+            if unsafe { next_head.as_ref().is_final() } {
+                let res = Self::advance_step(&mut next_head, index);
+                return res.map_break(|_advanced_to_next_block| ());
+            }
+            return ControlFlow::Break(())
+        };
+
+        while advance_if_final(self.index.wrapping_add(index)).is_continue() {
+            index += 1;
+            thread::yield_now();
+        }
+
+        next_head
+    }
+
+    fn advance_step<R>(block: &mut NonNull<Block<R>>, index: usize) -> ControlFlow<bool> {
+        let block_index = block::start_index(index);
+        
+        let next_block = {
+            let block = unsafe { block.as_ref() };
+            if block.is_at_index(block_index) {
+                return ControlFlow::Break(true);
+            }
+
+            match block.load_next(Acquire) {
+                Some(next_block) => {
+                    next_block
+                }
+                None => {
+                    return ControlFlow::Break(false)
+                }
+            }
+        };
+
+        *block = next_block;
+
+        ControlFlow::Continue(())
+    }
+
+    pub(crate) fn advance(&mut self, tx: &Tx<T>) {
+        if !Self::try_advancing_head(&mut self.head, self.index) {
+            return;
+        }
+        self.reclaim_blocks(tx);
+        self.index = self.index.wrapping_add(1);
+    }
+
 }
 
 impl<T> fmt::Debug for Rx<T> {


### PR DESCRIPTION
This PR introduces a `peek` method to the `mpsc::Receiver`. This allows consumers to inspect the next message in the queue without removing it, enabling use cases that require lookahead behavior. The `recv` method has been modified to utilise peek: if a message is available, `recv` reads the value, advances the internal queue, and updates the semaphore accordingly.

## Motivation
Currently,  the `mpsc::Receiver` does not provide a way to inspect the next message in the queue without consuming it. Users may want to make decisions based on the upcoming message before actually removing it from the channel.

## Solution

The peek method retrieves the next message without modifying the queue state. It works by:
1. Calling try_peeking_ahead() to determine the correct block to peek from, handling block transitions if needed.
2. Returning the peeked value via `block.peek(self.index)`.
3. `block.peek(slot_index)` checks if the slot at `slot_index` is ready using `ready_offset_read`. If ready, it returns a reference to the value without modifying the queue.